### PR TITLE
fix include path to use outside of ABS

### DIFF
--- a/drivers/nfc/pn548/pn548.c
+++ b/drivers/nfc/pn548/pn548.c
@@ -40,7 +40,7 @@
 #include <linux/wakelock.h>
 #include <linux/kthread.h>
 
-#include <pn548.h>
+#include "pn548.h"
 
 #define MAX_BUFFER_SIZE 512
 #define _A1_PN66T_

--- a/drivers/tspdrv/tspdrv.c
+++ b/drivers/tspdrv/tspdrv.c
@@ -40,7 +40,7 @@
 #include <linux/platform_device.h>
 #include <asm/uaccess.h>
 #include <asm/atomic.h>
-#include <tspdrv.h>
+#include "tspdrv.h"
 
 #define IMMVIBESPI_MULTIPARAM_SUPPORT
 
@@ -51,7 +51,7 @@ static int g_nTimerPeriodMs = 5; /* 5ms timer by default. This variable could be
 static atomic_t g_bRuntimeRecord;
 #endif
 
-#include <ImmVibeSPI.c>
+#include "ImmVibeSPI.c"
 #if (defined(VIBE_DEBUG) && defined(VIBE_RECORD)) || defined(VIBE_RUNTIME_RECORD)
 #include <tspdrvRecorder.c>
 #endif
@@ -92,11 +92,11 @@ static int g_nMajor;
 
 
 /* Needs to be included after the global variables because they use them */
-#include <tspdrvOutputDataHandler.c>
+#include "tspdrvOutputDataHandler.c"
 #ifdef CONFIG_HIGH_RES_TIMERS
-    #include <VibeOSKernelLinuxHRTime.c>
+    #include "VibeOSKernelLinuxHRTime.c"
 #else
-    #include <VibeOSKernelLinuxTime.c>
+    #include "VibeOSKernelLinuxTime.c"
 #endif
 
 asmlinkage void _DbgOut(int level, const char *fmt, ...)

--- a/drivers/usb/gadget/function/f_midi.c
+++ b/drivers/usb/gadget/function/f_midi.c
@@ -32,7 +32,7 @@
 #include <linux/usb/audio.h>
 #include <linux/usb/midi.h>
 
-#include "u_f.h"
+#include "../u_f.h"
 
 MODULE_AUTHOR("Ben Williamson");
 MODULE_LICENSE("GPL v2");

--- a/drivers/usb/gadget/function/f_mtp.c
+++ b/drivers/usb/gadget/function/f_mtp.c
@@ -40,7 +40,7 @@
 #include <linux/configfs.h>
 #include <linux/usb/composite.h>
 
-#include "configfs.h"
+#include "../configfs.h"
 
 #define MTP_RX_BUFFER_INIT_SIZE    1048576
 #define MTP_BULK_BUFFER_SIZE       16384

--- a/drivers/usb/gadget/function/f_rndis.c
+++ b/drivers/usb/gadget/function/f_rndis.c
@@ -27,7 +27,7 @@
 #include "u_ether_configfs.h"
 #include "u_rndis.h"
 #include "rndis.h"
-#include "configfs.h"
+#include "../configfs.h"
 
 /*
  * This function is an RNDIS Ethernet port -- a Microsoft protocol that's

--- a/firmware/Makefile
+++ b/firmware/Makefile
@@ -135,8 +135,7 @@ fw-shipped-$(CONFIG_USB_SERIAL_XIRCOM) += keyspan_pda/xircom_pgs.fw
 fw-shipped-$(CONFIG_USB_VICAM) += vicam/firmware.fw
 fw-shipped-$(CONFIG_VIDEO_CPIA2) += cpia2/stv0672_vp4.bin
 fw-shipped-$(CONFIG_YAM) += yam/1200.bin yam/9600.bin
-fw-shipped-$(CONFIG_TOUCHSCREEN_ATMEL_MXT) += mXT641T30AC.fw mXT640U10AA.fw \
-	mxt_641t_sharp_config.fw mxt_640u_lgd_config.fw
+fw-shipped-$(CONFIG_TOUCHSCREEN_ATMEL_MXT) += mXT641T30AC.fw mxt_641t_sharp_config.fw
 fw-shipped-$(CONFIG_TOUCHSCREEN_SYNAPTICS_DSX) += synaptics_jdi_incell.fw \
 	synaptics_lgd_incell.fw
 fw-shipped-$(CONFIG_TOUCHSCREEN_ST_FTS) += st_fts.fw

--- a/sound/soc/msm/msm8996.c
+++ b/sound/soc/msm/msm8996.c
@@ -32,7 +32,7 @@
 #include <sound/q6core.h>
 #include <sound/pcm_params.h>
 #include <sound/info.h>
-#include <device_event.h>
+#include "device_event.h"
 #include "qdsp6v2/msm-pcm-routing-v2.h"
 #include "../codecs/wcd9xxx-common.h"
 #include "../codecs/wcd9330.h"


### PR DESCRIPTION
fix include path for:
- pn548.h
- tspdrv.h
- ImmVibeSPI.c
- tspdrvOutputDataHandler.c
- VibeOSKernelLinuxHRTime.c
- VibeOSKernelLinuxTime.c
- u_f.h
- configfs.h

remove reference to not shipped touchscreen firmware mXT640U10AA.fw
