### PR TITLE
drivers: media: camera_v2: Append proper string to sensor name

### DIFF
--- a/drivers/media/platform/msm/camera_v2/sensor/msm_sensor_driver.c
+++ b/drivers/media/platform/msm/camera_v2/sensor/msm_sensor_driver.c
@@ -749,7 +749,7 @@ int32_t msm_sensor_driver_probe(void *setting,
 	if (strcmp(slave_info->eeprom_name, "ov4688") == 0) {
 		gemini_get_front_sensor_name(gemini_front_sensor_name);
 		if (hw_version_devid == 7)
-			strcat(gemini_front_sensor_name, "_capricorn");
+			strcat(gemini_front_sensor_name, "_a7");
 		pr_info("slave_info sensor_name = %s, front_sensor_name - %s\n",
 				slave_info->sensor_name, gemini_front_sensor_name);
 		if (strcmp(slave_info->sensor_name, gemini_front_sensor_name) != 0) {


### PR DESCRIPTION
* Xiaomi typo \o/
* Now in-kernel sensor name & retrived sensor name match
  -> capricorn ffc works

Change-Id: I2538fb62006b5eb8e926b3f44ed5762a9e115939