### PR TITLE
msm: mdss: Fix mutex protection for panel count data

### DIFF
--- a/drivers/video/fbdev/msm/mdss_fb.c
+++ b/drivers/video/fbdev/msm/mdss_fb.c
@@ -1055,6 +1055,7 @@ static ssize_t mdss_fb_set_panel_count(struct device *dev,
 		return size;
 	}
 
+	mutex_lock(&mfd->mdss_sysfs_lock);
 	getnstimeofday(&rtctime);
 	if (rtctime.tv_sec > kernel_rtctime) {
 		if (rtctime.tv_sec - kernel_rtctime > 10 * 365 * DAY_SECS) {
@@ -1071,8 +1072,7 @@ static ssize_t mdss_fb_set_panel_count(struct device *dev,
 		pr_err("RTC time rollback!\n");
 		pdata->panel_info.bootRTCtime = kernel_rtctime;
 	}
-
-	mutex_lock(&mfd->mdss_sysfs_lock);
+	mutex_unlock(&mfd->mdss_sysfs_lock);
 
 	return size;
 }


### PR DESCRIPTION
Move mutex lock at appropriate place and properly
release it to prevent deadlock.

Change-Id: I5fd4b04016ceabd2e531c882aee16e79411cdca6
Signed-off-by: TheStrix <parthbhatia98@gmail.com>