### PR TITLE
Fix library inclusion

### DIFF
--- a/drivers/misc/mediatek/thermal/mt8173/mtk_ts_bts.c
+++ b/drivers/misc/mediatek/thermal/mt8173/mtk_ts_bts.c
@@ -32,7 +32,7 @@
 #include "mach/mt_thermal.h"
 #include "mt-plat/mtk_thermal_platform.h"
 #include <linux/uidgid.h>
-#include <inc/tmp_bts.h>
+#include "inc/tmp_bts.h"
 #include <linux/slab.h>
 
 /*=============================================================


### PR DESCRIPTION
I've just tried to build "cappua" Kernel and build failed, here's the error:
`drivers/misc/mediatek/thermal/mt8173/mtk_ts_bts.c:35:25: fatal error: inc/tmp_bts.h: No such file or directory
 #include <inc/tmp_bts.h>
                         ^
compilation terminated.
make[5]: *** [scripts/Makefile.build:257: drivers/misc/mediatek/thermal/mt8173/mtk_ts_bts.o] Error 1
make[5]: *** Attesa per i processi non terminati....`

After applying this commit, I ran the build again and it worked fine.


GCC: [aarch64-linux-android-4.9](https://android.googlesource.com/platform/prebuilts/gcc/linux-x86/aarch64/aarch64-linux-android-4.9/).