### PR TITLE
Input drivers fixes for Tissot

### DIFF
--- a/drivers/input/fingerprint/goodix/platform.c
+++ b/drivers/input/fingerprint/goodix/platform.c
@@ -72,14 +72,14 @@ int gf_parse_dts(struct gf_dev *gf_dev)
 	pr_warn("--------gf_parse_dts start  haijun.--------\n");
 
 	/*get reset resource*/
-	rc = gf3208_request_named_gpio(gf_dev, "goodix, gpio_reset", &gf_dev->reset_gpio);
+	rc = gf3208_request_named_gpio(gf_dev, "goodix,gpio_reset", &gf_dev->reset_gpio);
 	if (rc) {
 		gf_dbg("Failed to request RESET GPIO. rc = %d\n", rc);
 		return -EPERM;
 	}
 
 	/*get irq resourece*/
-	rc = gf3208_request_named_gpio(gf_dev, "goodix, gpio_irq", &gf_dev->irq_gpio);
+	rc = gf3208_request_named_gpio(gf_dev, "goodix,gpio_irq", &gf_dev->irq_gpio);
 	if (rc) {
 		gf_dbg("Failed to request IRQ GPIO. rc = %d\n", rc);
 		return -EPERM;

--- a/drivers/input/touchscreen/ft5435/ft5435_ts.c
+++ b/drivers/input/touchscreen/ft5435/ft5435_ts.c
@@ -620,8 +620,8 @@ static int ft5435_ts_pinctrl_select(struct ft5435_ts_data *ft5435_data,
 static int ft5435_ts_suspend(struct device *dev)
 {
 	struct ft5435_ts_data *data = g_ft5435_ts_data;
-//	char i;
-//	u8 state = -1;
+	char i;
+	u8 state = -1;
 	u8 reg_addr;
 	u8 reg_value;
 
@@ -659,6 +659,19 @@ static int ft5435_ts_suspend(struct device *dev)
 		}
 	} else {
 		printk("i2c read OK , no rst\n");
+	}
+
+	if (gpio_is_valid(data->pdata->reset_gpio)) {
+		for (i = 0; i < 10; i++) {
+			ft5x0x_write_reg(data->client, 0xa5, 0x03);
+			ft5x0x_read_reg(data->client, 0xa5, &state);
+			if ((state != 0) && (state != 1)) {
+				printk("[FTS]Ft5435 TPDwrite  OK [%d]\n", i);
+				break;
+			} else {
+				printk("[FTS]Ft5435 TPDwrite  Error[%d]\n", i);
+			}
+		}
 	}
 
 	data->suspended = true;


### PR DESCRIPTION
The first patch fixes ft5435 suspend function and allows touchscreen driver to suspend properly.
The second patch sets proper GPIO namings to fix goodix fingerprint initialization.