### PR TITLE
ASoC:opa1622: Fix possible typo error

### DIFF
--- a/sound/soc/codecs/opa1622.c
+++ b/sound/soc/codecs/opa1622.c
@@ -199,8 +199,8 @@ static int opa1622_probe(struct snd_soc_codec *codec)
 	}
 
 	snd_soc_dapm_ignore_suspend(&codec->dapm, "OPA IN1");
-	snd_soc_dapm_ignore_suspend(&codec->dapm, "OPA IN1");
-	snd_soc_dapm_ignore_suspend(&codec->dapm, "OPA OUT2");
+	snd_soc_dapm_ignore_suspend(&codec->dapm, "OPA IN2");
+	snd_soc_dapm_ignore_suspend(&codec->dapm, "OPA OUT1");
 	snd_soc_dapm_ignore_suspend(&codec->dapm, "OPA OUT2");
 
 	opa1622->codec = codec;


### PR DESCRIPTION
Found by https://review.lineageos.org/#/c/LineageOS/android_kernel_xiaomi_msm8996/+/215691/2/sound/soc/codecs/opa1622.c
Bruno Martins<bgcngm@gmail.com>