### PR TITLE
drivers: input: nvt_touch: Use correct firmware name for whyred

### DIFF
--- a/drivers/input/touchscreen/nvt_touch/nt36xxx.h
+++ b/drivers/input/touchscreen/nvt_touch/nt36xxx.h
@@ -77,7 +77,7 @@ extern const uint16_t touch_key_array[TOUCH_KEY_NUM];
 extern const uint16_t gesture_key_array[];
 #endif
 #define BOOT_UPDATE_FIRMWARE 1
-#define BOOT_UPDATE_FIRMWARE_NAME "novatek/nt36672_miui_wayne.bin"
+#define BOOT_UPDATE_FIRMWARE_NAME "novatek/nt36672_miui_whyred.bin"
 
 
 #define NVT_TOUCH_ESD_PROTECT 0


### PR DESCRIPTION
 * Seems only whyred using this and wayne using nvt_touch_wayne