### PR TITLE
include/media/rc-map.h: RC_MAP_RC6_P2FP undeclared error

### DIFF
--- a/include/media/rc-map.h
+++ b/include/media/rc-map.h
@@ -206,7 +206,7 @@ void rc_map_init(void);
 #define RC_MAP_TREKSTOR                  "rc-trekstor"
 #define RC_MAP_TT_1500                   "rc-tt-1500"
 #define RC_MAP_TVX_HD_NEC                "rc-tvx-hd-nec"
-#define RC_MAP_RC6_PHILIPS               "rc-rc6-p2fp"
+#define RC_MAP_RC6_P2FP                  "rc-rc6-p2fp"
 #define RC_MAP_TWINHAN_DTV_CAB_CI        "rc-twinhan-dtv-cab-ci"
 #define RC_MAP_TWINHAN_VP1027_DVBS       "rc-twinhan1027"
 #define RC_MAP_VIDEOMATE_K100            "rc-videomate-k100"


### PR DESCRIPTION
Xiaomi's Kernel Source Does Not Have Correct rc-map.h entry for RC_MAP_RC6_P2FP.