### PR TITLE
Update scorpio-o-oss for Mi 5s and Mi 5s Plus

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,11 +12,12 @@
 | gemini-m-oss | Mi 5 | Android M | LA.HB.1.1.1.c2_rb1035 | [gemini-m-oss](https://github.com/MiCode/Xiaomi_Kernel_OpenSource/tree/gemini-m-oss) |
 | gucci-kk-oss | Redmi Note Dual SIM | Android KK | LNX.LA.3.7.2.1.c6-01400-8x16.0 | [gucci-kk-oss](https://github.com/MiCode/Xiaomi_Kernel_OpenSource/tree/gucci-kk-oss) |
 | hydrogen-m-oss | Mi Max, Mi Max Pro | Android M | LA.BR.1.3.4-05310-8976.0 | [hydrogen-m-oss](https://github.com/MiCode/Xiaomi_Kernel_OpenSource/tree/hydrogen-m-oss) |
-| hermes-l-oss | Redmi Note 2, Redmi Note 3 Dual Netcom | Android L | ALPS.L0.MP6.V3.18_lCSH6795.LWT.L_P228 | [hermes-l-oss](https://github.com/MiCode/Xiaomi_Kernel_OpenSource/tree/hermes-l-oss) |
+| hermes-l-oss | Redmi Note 2, Redmi Note 3 Dual Netcom | Android L | ALPS.L0.MP6.V3.18_LCSH6795.LWT.L_P228 | [hermes-l-oss](https://github.com/MiCode/Xiaomi_Kernel_OpenSource/tree/hermes-l-oss) |
 | ido-l-oss | Redmi 2, Redmi 3 | Android L | LA.BR.1.2.4-04410-8x16.0 | [ido-l-oss](https://github.com/MiCode/Xiaomi_Kernel_OpenSource/tree/ido-l-oss) |
 | jasmine-o-oss| Mi A2 | Android O | LA.UM.6.2.r1-06100-sdm660.0-1.151426.0.156675.1 | [jasmine-o-oss](https://github.com/MiCode/Xiaomi_Kernel_OpenSource/tree/jasmine-o-oss) |
 | jason-n-oss | Mi Note 3 | Android N | LA.UM.6.1.r1-08100-sdm660.0 | [jason-n-oss](https://github.com/MiCode/Xiaomi_Kernel_OpenSource/tree/jason-n-oss) |
 | kenzo-l-oss | Redmi Note 3 Full Netcom | Android L | LA.BR.1.3.2-04330-8976.0 | [kenzo-l-oss](https://github.com/MiCode/Xiaomi_Kernel_OpenSource/tree/kenzo-l-oss) |
+| kenzo-m-oss | Redmi Note 3 Full Netcom | Android M | LA.BR.1.3.4-00210-8976.0 | [kenzo-m-oss](https://github.com/MiCode/Xiaomi_Kernel_OpenSource/tree/kenzo-m-oss) |
 | land-m-oss | Redmi 3S, Redmi 3X | Android M | LA.UM.5.1-03810-8x37.0 | [land-m-oss](https://github.com/MiCode/Xiaomi_Kernel_OpenSource/tree/land-m-oss) |
 | latte-l-oss | Mi Pad 2 | Android L | imin.cht_rvp.a51.20150519-2015_ww20_b | [latte-l-oss](https://github.com/MiCode/Xiaomi_Kernel_OpenSource/tree/latte-l-oss) |
 | libra-l-oss | Mi 4S, Mi 4C, Mi Note Pro | Android L | LA.BF64.1.2.1.c1-05310-8x92.0 | [libra-l-oss](https://github.com/MiCode/Xiaomi_Kernel_OpenSource/tree/libra-l-oss) |

--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@
 | gemini-m-oss | Mi 5 | Android M | LA.HB.1.1.1.c2_rb1035 | [gemini-m-oss](https://github.com/MiCode/Xiaomi_Kernel_OpenSource/tree/gemini-m-oss) |
 | gucci-kk-oss | Redmi Note Dual SIM | Android KK | LNX.LA.3.7.2.1.c6-01400-8x16.0 | [gucci-kk-oss](https://github.com/MiCode/Xiaomi_Kernel_OpenSource/tree/gucci-kk-oss) |
 | hydrogen-m-oss | Mi Max, Mi Max Pro | Android M | LA.BR.1.3.4-05310-8976.0 | [hydrogen-m-oss](https://github.com/MiCode/Xiaomi_Kernel_OpenSource/tree/hydrogen-m-oss) |
+| hermes-l-oss | Redmi Note 2, Redmi Note 3 Dual Netcom | Android L | ALPS.L0.MP6.V3.18_lCSH6795.LWT.L_P228 | [hermes-l-oss](https://github.com/MiCode/Xiaomi_Kernel_OpenSource/tree/hermes-l-oss) |
 | ido-l-oss | Redmi 2, Redmi 3 | Android L | LA.BR.1.2.4-04410-8x16.0 | [ido-l-oss](https://github.com/MiCode/Xiaomi_Kernel_OpenSource/tree/ido-l-oss) |
 | jasmine-o-oss| Mi A2 | Android O | LA.UM.6.2.r1-06100-sdm660.0-1.151426.0.156675.1 | [jasmine-o-oss](https://github.com/MiCode/Xiaomi_Kernel_OpenSource/tree/jasmine-o-oss) |
 | jason-n-oss | Mi Note 3 | Android N | LA.UM.6.1.r1-08100-sdm660.0 | [jason-n-oss](https://github.com/MiCode/Xiaomi_Kernel_OpenSource/tree/jason-n-oss) |

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@
 | santoni-n-oss | Redmi 4X | Android N | LA.UM.5.6.r1-04600-89xx.0 | [santoni-n-oss](https://github.com/MiCode/Xiaomi_Kernel_OpenSource/tree/santoni-n-oss) |
 | scorpio-m-oss | Mi 5, Mi 5s, Mi 5s Plus, Mi MIX, Mi Note 2 | Android M | LA.HB.1.3.1_101rb1275 | [scorpio-m-oss](https://github.com/MiCode/Xiaomi_Kernel_OpenSource/tree/scorpio-m-oss) |
 | scorpio-n-oss | Mi 5, Mi 5s, Mi 5s Plus, Mi MIX, Mi Note 2 | Android N | LA.UM.5.5.r1-01800-8x96.0 | [scorpio-n-oss](https://github.com/MiCode/Xiaomi_Kernel_OpenSource/tree/scorpio-n-oss) |
-| scorpio-o-oss | Mi 5, Mi MIX, Mi Note 2 | Android O | LA.UM.6.5.r1-04300-8x96.0 | [scorpio-o-oss](https://github.com/MiCode/Xiaomi_Kernel_OpenSource/tree/scorpio-o-oss) |
+| scorpio-o-oss | Mi 5, Mi 5s, Mi 5s Plus, Mi MIX, Mi Note 2 | Android O | LA.UM.6.5.r1-04300-8x96.0 | [scorpio-o-oss](https://github.com/MiCode/Xiaomi_Kernel_OpenSource/tree/scorpio-o-oss) |
 | sirius-o-oss | Mi 8 SE | Android O | LA.UM.6.8.r2-00700-SDM710.0 | [sirius-o-oss](https://github.com/MiCode/Xiaomi_Kernel_OpenSource/tree/sirius-o-oss) |
 | thomas-kk-oss | Redmi 2 Standard | Android KK | LNX.LA.3.7.2.1.c6-02400-8x16.0 | [thomas-kk-oss](https://github.com/MiCode/Xiaomi_Kernel_OpenSource/tree/thomas-kk-oss) |
 | tiffany-n-oss | Mi 5X, Redmi 5 Plus | Android N | LA.UM.5.3-06310-89xx.0 | [tiffany-n-oss](https://github.com/MiCode/Xiaomi_Kernel_OpenSource/tree/tiffany-n-oss) |


### PR DESCRIPTION
They already got Miui China dev Oreo 8.10.11
update link: bigota.d.miui.com/8.10.11/miui_MI5SPlus_8.10.11_66c6bbfe92_8.0.zip