### PR TITLE
drivers: power: smb-lib: Drop redundant if

### DIFF
--- a/drivers/power/supply/qcom/smb-lib.c
+++ b/drivers/power/supply/qcom/smb-lib.c
@@ -2192,9 +2192,8 @@ static int smblib_dm_pulse(struct smb_charger *chg)
 #define MAX_PLUSE_COUNT_ALLOWED 8
 #elif (defined(CONFIG_KERNEL_CUSTOM_WHYRED) || defined (CONFIG_KERNEL_CUSTOM_TULIP))
 #define MAX_PLUSE_COUNT_ALLOWED 15
-#elif defined(CONFIG_KERNEL_CUSTOM_TULIP)
-#define MAX_PLUSE_COUNT_ALLOWED 15
 #endif
+
 int smblib_dp_dm(struct smb_charger *chg, int val)
 {
 	int target_icl_ua, rc = 0;


### PR DESCRIPTION
We don't need to redundantly check 'defined(CONFIG_KERNEL_CUSTOM_TULIP)' as it is already checked in the upper else-if condition.