### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,7 +109,7 @@
 | tulip-p-oss | Redmi Note 5, Redmi Note6 Pro, Mi 6X | Android P | LA.UM.7.2.r1-04900-sdm660.0 | [tulip-p-oss](https://github.com/MiCode/Xiaomi_Kernel_OpenSource/tree/tulip-p-oss) |
 | tucana-p-oss | Mi CC9 Pro | Android P | LA.UM.7.9.r1-05700-sm6150.0 | [tucana-p-oss](https://github.com/MiCode/Xiaomi_Kernel_OpenSource/tree/tucana-p-oss) |
 | tucana-q-oss | MI CC9 Pro | Android Q | LA.UM.8.9.r1-03800-sm6150.0-1 | [tucana-q-oss](https://github.com/MiCode/Xiaomi_Kernel_OpenSource/tree/tucana-q-oss) |
-| toco-q-oss | MI Note 10 | Android Q | LA.UM.8.9.r1-03800-sm6150.0-1 | [toco-q-oss](https://github.com/MiCode/Xiaomi_Kernel_OpenSource/tree/toco-q-oss) |
+| toco-q-oss | MI Note 10 Lite | Android Q | LA.UM.8.9.r1-03800-sm6150.0-1 | [toco-q-oss](https://github.com/MiCode/Xiaomi_Kernel_OpenSource/tree/toco-q-oss) |
 | ulysse-n-oss | Redmi Note 5A | Android N | LA.UM.5.6.r1-04600-89xx.0 | [ulysse-n-oss](https://github.com/MiCode/Xiaomi_Kernel_OpenSource/tree/ulysse-n-oss) |
 | umi-q-oss | Mi 10 Pro, Mi 10 | Android Q | LA.UM.8.12.r1-06000-sm8250.0 | [umi-q-oss](https://github.com/MiCode/Xiaomi_Kernel_OpenSource/tree/umi-q-oss) |
 | vangogh-q-oss | Mi 10 Lite 5G, Mi 10 Lite Zoom | Android Q | LA.UM.8.13.r1-04700-SAIPAN.0 | [vangogh-q-oss](https://github.com/MiCode/Xiaomi_Kernel_OpenSource/tree/vangogh-q-oss) |


### PR DESCRIPTION
fixed toco-q-oss description -> toco is Mi Note 10 Lite not Mi Note 10