### PR TITLE
ARM64: dts: Correct physical panel dimensions

### DIFF
--- a/arch/arm64/boot/dts/qcom/dsi-panel-g7b-37-02-0a-dsc-video.dtsi
+++ b/arch/arm64/boot/dts/qcom/dsi-panel-g7b-37-02-0a-dsc-video.dtsi
@@ -40,8 +40,8 @@
 		qcom,mdss-dsi-dma-trigger = "trigger_sw";
 		qcom,mdss-dsi-mdp-trigger = "none";
 		qcom,mdss-dsi-reset-sequence = <1 5>, <0 1>, <1 10>;
-		qcom,mdss-pan-physical-width-dimension = <700>;
-		qcom,mdss-pan-physical-height-dimension = <1540>;
+		qcom,mdss-pan-physical-width-dimension = <70>;
+		qcom,mdss-pan-physical-height-dimension = <154>;
 		qcom,cont-splash-enabled;
 		qcom,mdss-dsi-tx-eot-append;
 		qcom,dispparam-enabled;

--- a/arch/arm64/boot/dts/qcom/dsi-panel-g7b-37-02-0b-dsc-video.dtsi
+++ b/arch/arm64/boot/dts/qcom/dsi-panel-g7b-37-02-0b-dsc-video.dtsi
@@ -40,8 +40,8 @@
 		qcom,mdss-dsi-dma-trigger = "trigger_sw";
 		qcom,mdss-dsi-mdp-trigger = "none";
 		qcom,mdss-dsi-reset-sequence = <1 5>, <0 1>, <1 10>;
-		qcom,mdss-pan-physical-width-dimension = <700>;
-		qcom,mdss-pan-physical-height-dimension = <1540>;
+		qcom,mdss-pan-physical-width-dimension = <70>;
+		qcom,mdss-pan-physical-height-dimension = <154>;
 		qcom,cont-splash-enabled;
 		qcom,mdss-dsi-tx-eot-append;
 		qcom,dispparam-enabled;

--- a/arch/arm64/boot/dts/qcom/dsi-panel-g7b-42-02-0b-dsc-video.dtsi
+++ b/arch/arm64/boot/dts/qcom/dsi-panel-g7b-42-02-0b-dsc-video.dtsi
@@ -40,8 +40,8 @@
 		qcom,mdss-dsi-dma-trigger = "trigger_sw";
 		qcom,mdss-dsi-mdp-trigger = "none";
 		qcom,mdss-dsi-reset-sequence = <0 10>, <1 10>;
-		qcom,mdss-pan-physical-width-dimension = <680>;
-		qcom,mdss-pan-physical-height-dimension = <1360>;
+		qcom,mdss-pan-physical-width-dimension = <68>;
+		qcom,mdss-pan-physical-height-dimension = <136>;
 		qcom,cont-splash-enabled;
 		qcom,mdss-dsi-tx-eot-append;
 		qcom,dispparam-enabled;

--- a/arch/arm64/boot/dts/qcom/dsi-panel-ss-fhd-ea-f10-cmd.dtsi
+++ b/arch/arm64/boot/dts/qcom/dsi-panel-ss-fhd-ea-f10-cmd.dtsi
@@ -43,8 +43,8 @@
 		qcom,mdss-dsi-mdp-trigger = "none";
 		qcom,mdss-dsi-bl-dcs-type-ss-ea;
 		qcom,mdss-dsi-reset-sequence = <0 1>, <1 10>;
-		qcom,mdss-pan-physical-width-dimension = <680>;
-		qcom,mdss-pan-physical-height-dimension = <1470>;
+		qcom,mdss-pan-physical-width-dimension = <68>;
+		qcom,mdss-pan-physical-height-dimension = <147>;
 		qcom,mdss-dsi-te-pin-select = <1>;
 		qcom,mdss-dsi-wr-mem-start = <0x2c>;
 		qcom,mdss-dsi-wr-mem-continue = <0x3c>;

--- a/arch/arm64/boot/dts/qcom/dsi-panel-ss-fhd-eb-f10-cmd.dtsi
+++ b/arch/arm64/boot/dts/qcom/dsi-panel-ss-fhd-eb-f10-cmd.dtsi
@@ -44,8 +44,8 @@
 		qcom,mdss-dsi-mdp-trigger = "none";
 		qcom,mdss-dsi-bl-dcs-type-ss-eb;
 		qcom,mdss-dsi-reset-sequence = <0 1>, <1 10>;
-		qcom,mdss-pan-physical-width-dimension = <680>;
-		qcom,mdss-pan-physical-height-dimension = <1470>;
+		qcom,mdss-pan-physical-width-dimension = <68>;
+		qcom,mdss-pan-physical-height-dimension = <147>;
 		qcom,mdss-dsi-te-pin-select = <1>;
 		qcom,mdss-dsi-wr-mem-start = <0x2c>;
 		qcom,mdss-dsi-wr-mem-continue = <0x3c>;

--- a/arch/arm64/boot/dts/qcom/dsi-panel-xiaomi-f4-36-02-0b-fhd-cmd.dtsi
+++ b/arch/arm64/boot/dts/qcom/dsi-panel-xiaomi-f4-36-02-0b-fhd-cmd.dtsi
@@ -45,8 +45,8 @@
 		qcom,mdss-dsi-bl-dcs-type-ss-ea;
 		qcom,mdss-dsi-bl-xiaomi-f4-36-flag;
 		qcom,mdss-dsi-reset-sequence = <1 10>, <0 10>, <1 10>;
-		qcom,mdss-pan-physical-width-dimension = <690>;
-		qcom,mdss-pan-physical-height-dimension = <1490>;
+		qcom,mdss-pan-physical-width-dimension = <69>;
+		qcom,mdss-pan-physical-height-dimension = <149>;
 		qcom,mdss-dsi-te-pin-select = <1>;
 		qcom,mdss-dsi-wr-mem-start = <0x2c>;
 		qcom,mdss-dsi-wr-mem-continue = <0x3c>;

--- a/arch/arm64/boot/dts/qcom/dsi-panel-xiaomi-f4-41-06-0a-fhd-cmd.dtsi
+++ b/arch/arm64/boot/dts/qcom/dsi-panel-xiaomi-f4-41-06-0a-fhd-cmd.dtsi
@@ -44,8 +44,8 @@
 		qcom,mdss-dsi-bl-dcs-type-ss-ea;
 		qcom,mdss-dsi-bl-xiaomi-f4-41-flag;
 		qcom,mdss-dsi-reset-sequence = <0 1>, <1 10>;
-		qcom,mdss-pan-physical-width-dimension = <690>;
-		qcom,mdss-pan-physical-height-dimension = <1490>;
+		qcom,mdss-pan-physical-width-dimension = <69>;
+		qcom,mdss-pan-physical-height-dimension = <149>;
 		qcom,mdss-dsi-te-pin-select = <1>;
 		qcom,mdss-dsi-wr-mem-start = <0x2c>;
 		qcom,mdss-dsi-wr-mem-continue = <0x3c>;

--- a/arch/arm64/boot/dts/qcom/dsi-panel-xiaomi-f4-42-06-0c-fhd-cmd.dtsi
+++ b/arch/arm64/boot/dts/qcom/dsi-panel-xiaomi-f4-42-06-0c-fhd-cmd.dtsi
@@ -43,8 +43,8 @@
 		qcom,mdss-dsi-bl-dcs-type-ss-ea;
 		/* qcom,mdss-dsi-bl-xiaomi-f4-41-flag; */
 		qcom,mdss-dsi-reset-sequence = <0 1>, <1 10>;
-		qcom,mdss-pan-physical-width-dimension = <690>;
-		qcom,mdss-pan-physical-height-dimension = <1490>;
+		qcom,mdss-pan-physical-width-dimension = <69>;
+		qcom,mdss-pan-physical-height-dimension = <149>;
 		qcom,mdss-dsi-te-pin-select = <1>;
 		qcom,mdss-dsi-wr-mem-start = <0x2c>;
 		qcom,mdss-dsi-wr-mem-continue = <0x3c>;


### PR DESCRIPTION
* These values were multiplied by 10 from phoenix-q-oss
  to phoenix-r-oss which causes unexpected behaviour in
  some apps. (e.g. pictures are shown too small in Reddit
  app, sliding in Gboard is too sensitive)

* By dumping dtbo from MIUI V12.1.1.0.RFJCNXM we can observe
  that these increased dimensions are not used anymore.

Change-Id: Ia99595bf038d8f9302e36e5a02aae48912243c96