### PR TITLE
Release Kernel Source for Redmi Note 12 Turbo / Poco F5 (marble)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,167 +1,38 @@
-| Branch | Device | Android version | Base tag | Link |
-| :-: | :-: | :-: | :-: | :-: |
-| alioth-r-oss | Mi 10S, Redmi K40 | Android R | LA.UM.9.12.r1-08000-SMxx50.0 | [alioth-r-oss](https://github.com/MiCode/Xiaomi_Kernel_OpenSource/tree/alioth-r-oss) |   
-| andromeda-p-oss | Mi MIX 3 5G | Android P | LA.UM.7.1.r1-13000-sm8150.0 | [andromeda-p-oss](https://github.com/MiCode/Xiaomi_Kernel_OpenSource/tree/andromeda-p-oss) |
-| ares-r-oss | Redmi K40 Gaming | Android R | MTK | [ares-r-oss](https://github.com/MiCode/Xiaomi_Kernel_OpenSource/tree/ares-r-oss) |    
-| armani-jb-oss | Redmi 1S | Android JB | LNX.LA.3.2-09720-8x26.0 | [armani-jb-oss](https://github.com/MiCode/Xiaomi_Kernel_OpenSource/tree/armani-jb-oss) |
-| armani-kk-oss | Redmi 1S, Redmi Note Single SIM | Android KK | LNX.LA.3.5.2.2.2-00510-8x26.0 | [armani-kk-oss](https://github.com/MiCode/Xiaomi_Kernel_OpenSource/tree/armani-kk-oss) |
-| apollo-q-oss | Redmi K30S Ultra | Android Q | LA.UM.8.12.r1-10600-sm8250.0 | [apollo-q-oss](https://github.com/MiCode/Xiaomi_Kernel_OpenSource/tree/apollo-q-oss) |
-| begonia-p-oss | Redmi Note 8 Pro | Android P | MTK | [begonia-p-oss](https://github.com/MiCode/Xiaomi_Kernel_OpenSource/tree/begonia-p-oss) |
-| begonia-q-oss | Redmi Note 8 Pro | Android Q | MTK | [begonia-q-oss](https://github.com/MiCode/Xiaomi_Kernel_OpenSource/tree/begonia-q-oss) |
-| begonia-r-oss | Redmi Note 8 Pro | Android R | MTK | [begonia-r-oss](https://github.com/MiCode/Xiaomi_Kernel_OpenSource/tree/begonia-r-oss) |
-| biloba-r-oss | Redmi Note 8 | Android R | MTK | [biloba-r-oss](https://github.com/MiCode/Xiaomi_Kernel_OpenSource/tree/biloba-r-oss) |
-| bomb-q-oss | Redmi 10X, Redmi 10X Pro | Android Q | MTK | [bomb-q-oss](https://github.com/MiCode/Xiaomi_Kernel_OpenSource/tree/bomb-q-oss) |
-| cactus-o-oss | Redmi 6A, Redmi 6 | Android O | MTK | [cactus-o-oss](https://github.com/MiCode/Xiaomi_Kernel_OpenSource/tree/cactus-o-oss) |
-| cactus-p-oss | Redmi 6A, Redmi 6 | Android P | MTK | [cactus-p-oss](https://github.com/MiCode/Xiaomi_Kernel_OpenSource/tree/cactus-p-oss) |
-| cancro-kk-oss | Mi 3, Mi 4, Mi Note | Android KK | LNX.LA.3.5.2.2.1-04310-8x74.0 | [cancro-kk-oss](https://github.com/MiCode/Xiaomi_Kernel_OpenSource/tree/cancro-kk-oss) |
-| cannon-r-oss | Redmi Note 9 | Android R | MTK | [cannon-r-oss](https://github.com/MiCode/Xiaomi_Kernel_OpenSource/tree/cannon-r-oss) |   
-| cancro-m-oss | Mi 3, Mi 4, Mi Note | Android M | LA.BF.1.1.3-01310-8x74.0 | [cancro-m-oss](https://github.com/MiCode/Xiaomi_Kernel_OpenSource/tree/cancro-m-oss) |
-| cappu-n-oss | Mi Pad 3 | Android N | MTK | [cappu-n-oss](https://github.com/MiCode/Xiaomi_Kernel_OpenSource/tree/cappu-n-oss) |
-| cas-q-oss | Mi 10 Ultra, Mi 10 Pro, Mi 10, Redmi K30 Pro | Android Q | LA.UM.8.12.r1-10600-sm8250.0 | [cas-q-oss](https://github.com/MiCode/Xiaomi_Kernel_OpenSource/tree/cas-q-oss) |
-| cannon-q-oss | Redmi Note 9 | Android Q | MTK | [cannon-q-oss](https://github.com/MiCode/Xiaomi_Kernel_OpenSource/tree/cannon-q-oss) |
-| camellia-r-oss | Redmi Note 10 | Android R | MTK | [camellia-r-oss](https://github.com/MiCode/Xiaomi_Kernel_OpenSource/tree/camellia-r-oss) |  
-| cepheus-p-oss | Mi 9 | Android P | LA.UM.7.1.r1-07600-sm8150.0 | [cepheus-p-oss](https://github.com/MiCode/Xiaomi_Kernel_OpenSource/tree/cepheus-p-oss) |
-| cepheus-q-oss | Mi 9, Redmi K20 Pro | Android Q | LA.UM.8.1.r1-08700-sm8150.0 | [cepheus-q-oss](https://github.com/MiCode/Xiaomi_Kernel_OpenSource/tree/cepheus-q-oss) |
-| cezanne-q-oss | Redmi K30 Ultra | Android Q | MTK | [cezanne-q-oss](https://github.com/MiCode/Xiaomi_Kernel_OpenSource/tree/cezanne-q-oss) |
-| cezanne-r-oss | Redmi 10X, Redmi 10X Pro, Redmi K30 Ultra | Android R | MTK | [cezanne-r-oss](https://github.com/MiCode/Xiaomi_Kernel_OpenSource/tree/cezanne-r-oss) |   
-| chopin-r-oss | Redmi Note 10 Pro | Android R | MTK | [chopin-r-oss](https://github.com/MiCode/Xiaomi_Kernel_OpenSource/tree/chopin-r-oss) |  
-| clover-o-oss | Mi Pad 4 | Android O | LA.UM.6.2.r1-08100-sdm660.0 | [clover-o-oss](https://github.com/MiCode/Xiaomi_Kernel_OpenSource/tree/clover-o-oss) |
-| cmi-r-oss | Redmi K30S Ultra, Mi 10 Ultra, Mi 10 Pro, Redmi K30 Pro, Mi 10 | Android R | LA.UM.9.12.r1-08000-SMxx50.0 | [cmi-r-oss](https://github.com/MiCode/Xiaomi_Kernel_OpenSource/tree/cmi-r-oss) | 
-| courbet-r-oss | Mi 11 Lite | Android R | LA.UM.9.1.r1-06700-SMxxx0.0 | [courbet-r-oss](https://github.com/MiCode/Xiaomi_Kernel_OpenSource/tree/courbet-r-oss) |   
-| crux-p-oss | Mi9 Pro 5G | Android P | LA.UM.7.1.r1-15600-sm8150.0 | [crux-p-oss](https://github.com/MiCode/Xiaomi_Kernel_OpenSource/tree/crux-p-oss) |
-| curtana-q-oss | Redmi Note 9 Pro,Redmi Note 9 Pro Max | Android Q | LA.UM.8.9.r1-07100-SM6xx.0 | [curtana-q-oss](https://github.com/MiCode/Xiaomi_Kernel_OpenSource/tree/curtana-q-oss) |
-| dagu-s-oss | Xiaomi Pad 5 pro 12.4 | Android S | LA.UM.9.12.r1-13300-SMxx50.QSSI12.0-1 | [dagu-s-oss](https://github.com/MiCode/Xiaomi_Kernel_OpenSource/tree/dagu-s-oss) |
-| daisy-o-oss | Mi A2 lite, Redmi 6pro | Android O | LA.UM.6.6.r1-07400-89xx.0-1 | [daisy-o-oss](https://github.com/MiCode/Xiaomi_Kernel_OpenSource/tree/daisy-o-oss) |
-| daisy-p-oss | Mi A2 lite | Android P | LA.UM.7.6.r1-02800-89xx.0 | [daisy-p-oss](https://github.com/MiCode/Xiaomi_Kernel_OpenSource/tree/daisy-p-oss) |
-| daisy-q-oss | Mi A2 Lite| Android Q | LA.UM.8.6.r1-02600-89xx.0 | [daisy-q-oss](https://github.com/MiCode/Xiaomi_Kernel_OpenSource/tree/daisy-q-oss) |
-| dandelion-q-oss | Redmi 9C, Redmi POCO C3, Redmi 9A | Android Q | MTK | [dandelion-q-oss](https://github.com/MiCode/Xiaomi_Kernel_OpenSource/tree/dandelion-q-oss) |
-| davinci-p-oss | Redmi K20 | Android P | LA.UM.7.9.r1-03300-sm6150.0 | [davinci-p-oss](https://github.com/MiCode/Xiaomi_Kernel_OpenSource/tree/davinci-p-oss) |
-| dior-kk-oss | Redmi Note Single SIM | Android KK | LNX.LA.3.5.2.2.2-00510-8x26.0 | [dior-kk-oss](https://github.com/MiCode/Xiaomi_Kernel_OpenSource/tree/dior-kk-oss) |
-| dipper-o-oss | Mi 8/MI 8 Explorer Edition/POCOPHONE F1 | Android 8.1 | LA.UM.6.3.r4-03000-sdm845.0 | [dipper-o-oss](https://github.com/MiCode/Xiaomi_Kernel_OpenSource/tree/dipper-o-oss) |
-| dipper-p-oss | MIX2S, MIX3, MI 8, POCOPHONE F1, MI 8UD, MI 8 Explorer Edition | Android P | LA.UM.7.3.r1-04500-sdm845.0 | [dipper-p-oss](https://github.com/MiCode/Xiaomi_Kernel_OpenSource/tree/dipper-p-oss) |
-| dipper-q-oss | MI 8, MIX2S, POCOPHONE F1, MI 8UD, MIX 3, MI 8 Explorer Edition | Android Q | LA.UM.8.3.r1-05800-sdm845.0 | [dipper-q-oss](https://github.com/MiCode/Xiaomi_Kernel_OpenSource/tree/dipper-q-oss) |
-| earth-s-oss | Redmi 12C, POCO C55 | Android S | alps-mp-s0.mp1.tc8sp2-cs1-V1.3 | [earth-s-oss](https://github.com/MiCode/Xiaomi_Kernel_OpenSource/tree/earth-s-oss) |
-| elish-r-oss | Xiaomi Pad 5 Pro, Xiaomi Pad 5 Pro 5G | Android R | LA.UM.9.12.r1-08000-SMxx50.0 | [elish-r-oss](https://github.com/MiCode/Xiaomi_Kernel_OpenSource/tree/elish-r-oss) |
-| ferrari-l-oss | Mi 4i | Android L | LA.BR.1.1.2-01120-8x16.0 | [ferrari-l-oss](https://github.com/MiCode/Xiaomi_Kernel_OpenSource/tree/ferrari-l-oss) |
-| gram-q-oss | MI POCO M2 Pro,Redmi Note 9 Pro,Redmi Note 9 Pro Max | Android Q | LA.UM.8.9.r1-07100-SM6xx.0 | [gram-q-oss](https://github.com/MiCode/Xiaomi_Kernel_OpenSource/tree/gram-q-oss) |
-| gemini-m-oss | Mi 5 | Android M | LA.HB.1.1.1.c2_rb1035 | [gemini-m-oss](https://github.com/MiCode/Xiaomi_Kernel_OpenSource/tree/gemini-m-oss) |
-| ginkgo-p-oss | Redmi Note 8 | Android P | LA.UM.7.11.r1-02700-NICOBAR.0 | [ginkgo-p-oss](https://github.com/MiCode/Xiaomi_Kernel_OpenSource/tree/ginkgo-p-oss) |
-| ginkgo-q-oss | Redmi Note 8, Redmi Note 8T | Android Q | LA.UM.8.11.r1-02400-NICOBAR.0 | [ginkgo-q-oss](https://github.com/MiCode/Xiaomi_Kernel_OpenSource/tree/ginkgo-q-oss) |
-| grus-p-oss | Mi 8SE, Mi 9SE | Android P | LA.UM.7.8.r1-04400-SDM710.0 | [grus-p-oss](https://github.com/MiCode/Xiaomi_Kernel_OpenSource/tree/grus-p-oss) |
-| gucci-kk-oss | Redmi Note Dual SIM | Android KK | LNX.LA.3.7.2.1.c6-01400-8x16.0 | [gucci-kk-oss](https://github.com/MiCode/Xiaomi_Kernel_OpenSource/tree/gucci-kk-oss) |
-| gauguin-q-oss | Redmi Note 9 Pro | Android Q | LA.UM.8.13.r1-09200-SAIPAN.0 | [gauguin-q-oss](https://github.com/MiCode/Xiaomi_Kernel_OpenSource/tree/gauguin-q-oss) |
-| gauguin-r-oss | Redmi Note 9 Pro | Android R | LA.UM.9.12.r1-08000-SMxx50.0 | [gauguin-r-oss](https://github.com/MiCode/Xiaomi_Kernel_OpenSource/tree/gauguin-r-oss) |
-| hennessy-l-oss | Redmi Note3,Redmi Note2,Redmi Note2 Pro | Android L | MTK | [hennessy-l-oss](https://github.com/MiCode/Xiaomi_Kernel_OpenSource/tree/hennessy-l-oss) |
-| haydn-r-oss | Redmi K40 Pro | Android R | LA.UM.9.14.r1-11500-LAHAINA.0 | [haydn-r-oss](https://github.com/MiCode/Xiaomi_Kernel_OpenSource/tree/haydn-r-oss) |
-| hydrogen-m-oss | Mi Max, Mi Max Pro | Android M | LA.BR.1.3.4-05310-8976.0 | [hydrogen-m-oss](https://github.com/MiCode/Xiaomi_Kernel_OpenSource/tree/hydrogen-m-oss) |
-| ido-l-oss | Redmi 2, Redmi 3 | Android L | LA.BR.1.2.4-04410-8x16.0 | [ido-l-oss](https://github.com/MiCode/Xiaomi_Kernel_OpenSource/tree/ido-l-oss) |
-| jasmine-o-oss| Mi A2 | Android O | LA.UM.6.2.r1-06100-sdm660.0-1.151426.0.156675.1 | [jasmine-o-oss](https://github.com/MiCode/Xiaomi_Kernel_OpenSource/tree/jasmine-o-oss) |
-| jasmine-p-oss| Mi A2 | Android P | LA.UM.7.2.r1-04900-sdm660.0 | [jasmine-p-oss](https://github.com/MiCode/Xiaomi_Kernel_OpenSource/tree/jasmine-p-oss) |
-| jasmine-q-oss| Mi A2 | Android Q | LA.UM.8.2.r1-04300-sdm660.0 | [jasmine-q-oss](https://github.com/MiCode/Xiaomi_Kernel_OpenSource/tree/jasmine-q-oss) |
-| jason-n-oss | Mi Note 3 | Android N | LA.UM.6.1.r1-08100-sdm660.0 | [jason-n-oss](https://github.com/MiCode/Xiaomi_Kernel_OpenSource/tree/jason-n-oss) |
-| jason-p-oss | Mi Note 3 | Android P | LA.UM.7.2.r1-05200-sdm660.0 | [jason-p-oss](https://github.com/MiCode/Xiaomi_Kernel_OpenSource/tree/jason-p-oss) |
-| kenzo-l-oss | Redmi Note 3 Full Netcom | Android L | LA.BR.1.3.2-04330-8976.0 | [kenzo-l-oss](https://github.com/MiCode/Xiaomi_Kernel_OpenSource/tree/kenzo-l-oss) |
-| land-m-oss | Redmi 3S, Redmi 3X | Android M | LA.UM.5.1-03810-8x37.0 | [land-m-oss](https://github.com/MiCode/Xiaomi_Kernel_OpenSource/tree/land-m-oss) |
-| latte-l-oss | Mi Pad 2 | Android L | imin.cht_rvp.a51.20150519-2015_ww20_b | [latte-l-oss](https://github.com/MiCode/Xiaomi_Kernel_OpenSource/tree/latte-l-oss) |
-| laurel-q-oss| Mi A3 | Android Q | LA.UM.8.11.r1-01200-NICOBAR.0 | [laurel-q-oss](https://github.com/MiCode/Xiaomi_Kernel_OpenSource/tree/laurel-q-oss) |
-| laurus-p-oss| MI CC 9e, Mi A3 | Android P | LA.UM.7.11.r1-02100-NICOBAR.0 | [laurus-p-oss](https://github.com/MiCode/Xiaomi_Kernel_OpenSource/tree/laurus-p-oss) |
-| laurus-q-oss | MI CC 9e | Android Q | LA.UM.8.11.r1-01200-NICOBAR.0-2 | [laurus-q-oss](https://github.com/MiCode/Xiaomi_Kernel_OpenSource/tree/laurus-q-oss) |
-| lavender-p-oss| Redmi Note 7 | Android P | LA.UM.7.2.r1-04900-sdm660.0 | [lavender-p-oss](https://github.com/MiCode/Xiaomi_Kernel_OpenSource/tree/lavender-p-oss) |
-| lavender-q-oss | Redmi Note 7 | Android Q | LA.UM.8.2.r1-04800-sdm660.0-1 | [lavender-q-oss](https://github.com/MiCode/Xiaomi_Kernel_OpenSource/tree/lavender-q-oss) |
-| lancelot-q-oss | Redmi 10X 4G,Redmi 9,Redmi POCO M2 | Android Q | MTK | [lancelot-q-oss](https://github.com/MiCode/Xiaomi_Kernel_OpenSource/tree/lancelot-q-oss) |
-| laurel-r-oss | Mi A3 | Android R | LA.UM.9.11.r1-02100-NICOBAR.0 | [laurel-r-oss](https://github.com/MiCode/Xiaomi_Kernel_OpenSource/tree/laurel-r-oss) | 
-| libra-l-oss | Mi 4S, Mi 4C, Mi Note Pro | Android L | LA.BF64.1.2.1.c1-05310-8x92.0 | [libra-l-oss](https://github.com/MiCode/Xiaomi_Kernel_OpenSource/tree/libra-l-oss) |
-| libra-n-oss | Mi 4S, Mi 4C, Mi Note Pro | Android N | LA.BF64.1.2.3-01110-8x94.0 | [libra-n-oss](https://github.com/MiCode/Xiaomi_Kernel_OpenSource/tree/libra-n-oss) |
-| lisa-r-oss | Mi 11 LE | Android R | LA.UM.9.14.r1-16700-LAHAINA.0 | [lisa-r-oss](https://github.com/MiCode/Xiaomi_Kernel_OpenSource/tree/lisa-r-oss) |
-| lmi-q-oss | Redmi K30 Pro| Android Q | LA.UM.8.12.r1-06000-sm8250.0 | [lmi-q-oss](https://github.com/MiCode/Xiaomi_Kernel_OpenSource/tree/lmi-q-oss) |
-| lotus-o-oss | Mi Play | Android O | MTK | [lotus-o-oss](https://github.com/MiCode/Xiaomi_Kernel_OpenSource/tree/lotus-o-oss) |
-| lime-q-oss | Redmi Note 9 4G,Redmi POCO M3 | Android Q | LA.UM.8.15.r1-06600-KAMORTA.0 | [lime-q-oss](https://github.com/MiCode/Xiaomi_Kernel_OpenSource/tree/lime-q-oss) |
-| markw-m-oss | Redmi 4 Premium | Android M | LA.UM.5.3-03710-89xx.0 | [markw-m-oss](https://github.com/MiCode/Xiaomi_Kernel_OpenSource/tree/markw-m-oss) |
-| mi1_kernel | Mi 1 | Android ICS | M8260AAABQNLZA313065 | [mi1_kernel](https://github.com/MiCode/mi1_kernel) |
-| mi2_kernel | Mi 2, Mi 2A, Mi 2S | Android KK | A8064AAAAANLYA103051 | [mi2_kernel](https://github.com/MiCode/mi2_kernel) |
-| mido-m-oss | Redmi Note 4X Standard | Android M | LA.UM.5.3-06310-89xx.0 | [mido-m-oss](https://github.com/MiCode/Xiaomi_Kernel_OpenSource/tree/mido-m-oss) |
-| mido-n-oss | Redmi Note 4X Standard | Android N | LA.UM.5.6.r1-02100-89xx.0 | [mido-n-oss](https://github.com/MiCode/Xiaomi_Kernel_OpenSource/tree/mido-n-oss) |
-| mocha-kk-oss | Mi Pad | Android KK | tegra-19r15.1-android-4.4 | [mocha-kk-oss](https://github.com/MiCode/Xiaomi_Kernel_OpenSource/tree/mocha-kk-oss) |
-| mojito-r-oss | Redmi Note 10 | Android R | LA.UM.9.1.r1-07700-SMxxx0.0 | [mojito-r-oss](https://github.com/MiCode/Xiaomi_Kernel_OpenSource/tree/mojito-r-oss) |
-| merlin-r-oss | Redmi 10X 4G, Redmi 9 and POCO M2 | Android R | MTK | [merlin-r-oss](https://github.com/MiCode/Xiaomi_Kernel_OpenSource/tree/merlin-r-oss) | 
-| nabu-r-oss | Xiaomi Pad 5 | Android R | LA.UM.9.1.r1-07000-SMxxx0.0 | [nabu-r-oss](https://github.com/MiCode/Xiaomi_Kernel_OpenSource/tree/nabu-r-oss) |
-| nitrogen-o-oss | MI MAX3,Mi Note 3 | Android O | LA.UM.6.2.r1-07400-sdm660.0 | [nitrogen-o-oss](https://github.com/MiCode/Xiaomi_Kernel_OpenSource/tree/nitrogen-o-oss) |
-| nitrogen-p-oss | MI MAX3,MI 8Lite | Android P | LA.UM.7.2.r1-05200-sdm660.0 | [nitrogen-p-oss](https://github.com/MiCode/Xiaomi_Kernel_OpenSource/tree/nitrogen-p-oss) |
-| nitrogen-q-oss | MI MAX3,MI 8Lite| Android Q | LLA.UM.8.2.r1-04300-sdm660.0 | [nitrogen-q-oss](https://github.com/MiCode/Xiaomi_Kernel_OpenSource/tree/nitrogen-q-oss) |
-| mona-r-oss | Xiaomi Civi | Android R | LA.UM.9.14.r1-11500-LAHAINA.0 | [mona-r-oss](https://github.com/MiCode/Xiaomi_Kernel_OpenSource/tree/mona-r-oss) |
-| odin-r-oss | MIX 4 | Android R | LA.UM.9.14.r1-16700-LAHAINA.0 | [odin-r-oss](https://github.com/MiCode/Xiaomi_Kernel_OpenSource/tree/odin-r-oss) |  
-| olive-p-oss | Redmi 8, Redmi 8A | Android P | LA.UM.7.6.2.r1-08100-89xx.0 | [olive-p-oss](https://github.com/MiCode/Xiaomi_Kernel_OpenSource/tree/olive-p-oss) |
-| olive-q-oss | Redmi 7A, Redmi 8, Redmi 8A, Redmi 8A | Android Q | LA.UM.8.6.2.r1-05300-89xx.0 | [olive-q-oss](https://github.com/MiCode/Xiaomi_Kernel_OpenSource/tree/olive-q-oss) |
-| olivewood-p-oss  | Redmi 8A Dual | Android P | LA.UM.7.6.2.r1-08100-89xx.0 | [olivewood-p-oss](https://github.com/MiCode/Xiaomi_Kernel_OpenSource/tree/olivewood-p-oss) |
-| onc-p-oss | Redmi 7, Redmi Y3 | Android P | LA.UM.7.6.2.r1-04200-89xx.0 | [onc-p-oss](https://github.com/MiCode/Xiaomi_Kernel_OpenSource/tree/onc-p-oss) |
-| onc-q-oss | Redmi 7, Redmi Y3 | Android Q | LA.UM.8.6.2.r1-04900-89xx.0 | [onc-q-oss](https://github.com/MiCode/Xiaomi_Kernel_OpenSource/tree/onc-q-oss) |
-| oxygen-n-oss | Mi Max 2 | Android N | LA.UM.5.6.r1-01900-89xx.0 | [oxygen-n-oss](https://github.com/MiCode/Xiaomi_Kernel_OpenSource/tree/oxygen-n-oss) |
-| perseus-p-oss | MIX 3 | Android P | LA.UM.7.3.r1-04500-sdm845.0 | [perseus-p-oss](https://github.com/MiCode/Xiaomi_Kernel_OpenSource/tree/perseus-p-oss) |
-| phoenix-q-oss | Redmi K30, Redmi K20 | Android Q | LA.UM.8.9.r1-03800-sm6150.0 | [phoenix-q-oss](https://github.com/MiCode/Xiaomi_Kernel_OpenSource/tree/phoenix-q-oss) |
-| phoenix-r-oss | Redmi K20, Redmi K30, MI Note 10 Lite, MI CC9 Pro | Android R | LA.UM.9.1.r1-06700-SMxxx0.0-1 | [phoenix-r-oss](https://github.com/MiCode/Xiaomi_Kernel_OpenSource/tree/phoenix-r-oss) |
-| picasso-q-oss | Redmi K30 5G | Android Q | LA.UM.8.13.r1-03300-SAIPAN.0 | [picasso-q-oss](https://github.com/MiCode/Xiaomi_Kernel_OpenSource/tree/picasso-q-oss) |
-| picasso-r-oss | Mi 10 Lite 5G, Redmi K30 5G, Mi 10 Lite Zoom | Android R | LA.UM.9.12.r1-08000-SMxx50.0 | [picasso-r-oss](https://github.com/MiCode/Xiaomi_Kernel_OpenSource/tree/picasso-r-oss) |
-| pissarro-r-oss | Redmi Note 11 Pro, Redmi Note 11 Pro+ | Android R | MTK | [pissarro-r-oss](https://github.com/MiCode/Xiaomi_Kernel_OpenSource/tree/pissarro-r-oss) |
-| pine-p-oss | Redmi 7A | Android P | LA.UM.7.6.2.r1-08100-89xx.0 | [pine-p-oss](https://github.com/MiCode/Xiaomi_Kernel_OpenSource/tree/pine-p-oss) |
-| pisces-kk-oss | Mi 3 China Mobile | Android KK | tegra-17r18-android-4.2 | [pisces-kk-oss](https://github.com/MiCode/Xiaomi_Kernel_OpenSource/tree/pisces-kk-oss) |
-| platina-o-oss | MI 8 Lite | Android O | LA.UM.6.2.r1-07400-sdm660.0 | [platina-o-oss](https://github.com/MiCode/Xiaomi_Kernel_OpenSource/tree/platina-o-oss) |
-| polaris-o-oss | Mi MIX 2S | Android O | LA.UM.6.3.r1_r00455 | [polaris-o-oss](https://github.com/MiCode/Xiaomi_Kernel_OpenSource/tree/polaris-o-oss) |
-| psyche-r-oss | Mi 12X | Android R | LA.UM.9.12.r1-08000-SMxx50.0 | [psyche-r-oss](https://github.com/MiCode/Xiaomi_Kernel_OpenSource/tree/psyche-r-oss) |
-| pyxis-p-oss | MI CC 9, MI CC 9 Meitu Edition | Android P | LA.UM.7.8.r1-04400-SDM710.0 | [pyxis-p-oss](https://github.com/MiCode/Xiaomi_Kernel_OpenSource/tree/pyxis-p-oss) |
-| raphael-p-oss | Redmi K20 Pro | Android P | LA.UM.7.1.r1-12100-sm8150.0 | [raphael-p-oss](https://github.com/MiCode/Xiaomi_Kernel_OpenSource/tree/raphael-p-oss) |
-| redwood-s-oss | Redmi Note 12 Pro Speed, POCO X5 Pro 5G | Android S | LA.UM.9.14.r1-18200-LAHAINA.QSSI12.0 | [redwood-s-oss](https://github.com/MiCode/Xiaomi_Kernel_OpenSource/tree/redwood-s-oss) |
-| riva-n-oss | Redmi 4A, Redmi 5, Redmi 5A | Android N | LA.UM.5.6.r1-05900-89xx.0 | [riva-n-oss](https://github.com/MiCode/Xiaomi_Kernel_OpenSource/tree/riva-n-oss) |
-| riva-o-oss | Redmi 5, Redmi 5A | Android O | LA.UM.6.6.r1-09900-89xx.0 | [riva-o-oss](https://github.com/MiCode/Xiaomi_Kernel_OpenSource/tree/riva-o-oss) |
-| rosemary-r-oss | Redmi Note 10S | Android R | MTK | [rosemary-r-oss](https://github.com/MiCode/Xiaomi_Kernel_OpenSource/tree/rosemary-r-oss) |   
-| sagit-n-oss | Mi 6, Mi MIX 2 | Android N | MSM8998.LA.1.1.r1-00232-STD.PROD-3 | [sagit-n-oss](https://github.com/MiCode/Xiaomi_Kernel_OpenSource/tree/sagit-n-oss) |
-| sagit-o-oss | Mi 6, Mi MIX 2 | Android O | LA.UM.6.4.r1-04900-8x98.0 | [sagit-o-oss](https://github.com/MiCode/Xiaomi_Kernel_OpenSource/tree/sagit-o-oss) |
-| sagit-p-oss | Mi 6, Mi MIX 2 | Android P | LA.UM.7.4.r1-04700-8x98.0 | [sagit-p-oss](https://github.com/MiCode/Xiaomi_Kernel_OpenSource/tree/sagit-p-oss) |
-| sakura-o-oss | Redmi 6Pro, Redmi 5Plus,Mi 5X | Android O | LA.UM.6.6.r1-07400-89xx.0 | [sakura-o-oss](https://github.com/MiCode/Xiaomi_Kernel_OpenSource/tree/sakura-o-oss) |
-| sakura-p-oss | Redmi 6Pro | Android P | LA.UM.7.6.r1-02800-89xx.0 | [sakura-p-oss](https://github.com/MiCode/Xiaomi_Kernel_OpenSource/tree/sakura-p-oss) |
-| santoni-n-oss | Redmi 4X | Android N | LA.UM.5.6.r1-04600-89xx.0 | [santoni-n-oss](https://github.com/MiCode/Xiaomi_Kernel_OpenSource/tree/santoni-n-oss) |
-| scorpio-m-oss | Mi 5, Mi 5s, Mi 5s Plus, Mi MIX, Mi Note 2 | Android M | LA.HB.1.3.1_101rb1275 | [scorpio-m-oss](https://github.com/MiCode/Xiaomi_Kernel_OpenSource/tree/scorpio-m-oss) |
-| scorpio-n-oss | Mi 5, Mi 5s, Mi 5s Plus, Mi MIX, Mi Note 2 | Android N | LA.UM.5.5.r1-01800-8x96.0 | [scorpio-n-oss](https://github.com/MiCode/Xiaomi_Kernel_OpenSource/tree/scorpio-n-oss) |
-| scorpio-o-oss | Mi 5, Mi 5s, Mi 5s Plus, Mi MIX, Mi Note 2 | Android O | LA.UM.6.5.r1-04300-8x96.0 | [scorpio-o-oss](https://github.com/MiCode/Xiaomi_Kernel_OpenSource/tree/scorpio-o-oss) |
-| selene-r-oss | Redmi 10 Prime | Android R | MTK | [selene-r-oss](https://github.com/MiCode/Xiaomi_Kernel_OpenSource/tree/selene-r-oss) |
-| sirius-o-oss | Mi 8 SE | Android O | LA.UM.6.8.r2-00700-SDM710.0 | [sirius-o-oss](https://github.com/MiCode/Xiaomi_Kernel_OpenSource/tree/sirius-o-oss) |
-| sirius-q-oss | MI 8SE, MI 9SE, MI CC 9, MI CC 9 Meitu Edition | Android Q | LA.UM.8.8.r1-05100-SDM710.0 | [sirius-q-oss](https://github.com/MiCode/Xiaomi_Kernel_OpenSource/tree/sirius-q-oss) |
-| star-r-oss | Mi 11 Lite 5G, Mi 11 Pro, Mi 11 Ultra, MIX FOLD | Android R | LA.UM.9.14.r1-11500-LAHAINA.0 | [star-r-oss](https://github.com/MiCode/Xiaomi_Kernel_OpenSource/tree/star-r-oss) |  
-| surya-q-oss | Redmi POCO X3 | Android Q | LA.UM.8.9.r1-09300-SM6xx.0 | [surya-q-oss](https://github.com/MiCode/Xiaomi_Kernel_OpenSource/tree/surya-q-oss) |
-| sweet-r-oss | Redmi Note 10 Pro | Android R | LA.UM.9.1.r1-06700-SMxxx0.0-1 | [sweet-r-oss](https://github.com/MiCode/Xiaomi_Kernel_OpenSource/tree/sweet-r-oss) |
-| taoyao-s-oss | Xiaomi 12 Lite | Android S | LA.UM.9.14.r1-18300.05-LAHAINA.QSSI12.0-1 | [taoyao-s-oss](https://github.com/MiCode/Xiaomi_Kernel_OpenSource/tree/taoyao-s-oss) |
-| thomas-kk-oss | Redmi 2 Standard | Android KK | LNX.LA.3.7.2.1.c6-02400-8x16.0 | [thomas-kk-oss](https://github.com/MiCode/Xiaomi_Kernel_OpenSource/tree/thomas-kk-oss) |
-| tiare-o-oss | Redmi Go | Android O | LA.UM.6.6.r1-09900-89xx.0 | [tiare-o-oss](https://github.com/MiCode/Xiaomi_Kernel_OpenSource/tree/tiare-o-oss) |
-| tiffany-n-oss | Mi 5X, Redmi 5 Plus | Android N | LA.UM.5.3-06310-89xx.0 | [tiffany-n-oss](https://github.com/MiCode/Xiaomi_Kernel_OpenSource/tree/tiffany-n-oss) |
-| tissot-n-oss | Mi A1 | Android N | LA.UM.5.3-06310-89xx.0 | [tissot-n-oss](https://github.com/MiCode/Xiaomi_Kernel_OpenSource/tree/tissot-n-oss) |
-| tissot-o-oss | Mi A1 | Android 8.0 | LA.UM.6.6.r1-04000-89xx.0 | [tissot-o-oss](https://github.com/MiCode/Xiaomi_Kernel_OpenSource/tree/tissot-o-oss) |
-| tissot-o-oss-8.1 | Mi A1 | Android 8.1 | LA.UM.6.6.r1-08600-89xx.0 | [tissot-o-oss-8.1](https://github.com/MiCode/Xiaomi_Kernel_OpenSource/tree/tissot-o-oss-8.1) |
-| tissot-p-oss | Mi A1 | Android P | LA.UM.7.6.r1-02800-89xx.0 | [tissot-p-oss](https://github.com/MiCode/Xiaomi_Kernel_OpenSource/tree/tissot-p-oss) |
-| tulip-p-oss | Redmi Note 5, Redmi Note6 Pro, Mi 6X | Android P | LA.UM.7.2.r1-04900-sdm660.0 | [tulip-p-oss](https://github.com/MiCode/Xiaomi_Kernel_OpenSource/tree/tulip-p-oss) |
-| tucana-p-oss | Mi CC9 Pro | Android P | LA.UM.7.9.r1-05700-sm6150.0 | [tucana-p-oss](https://github.com/MiCode/Xiaomi_Kernel_OpenSource/tree/tucana-p-oss) |
-| tucana-q-oss | MI CC9 Pro | Android Q | LA.UM.8.9.r1-03800-sm6150.0-1 | [tucana-q-oss](https://github.com/MiCode/Xiaomi_Kernel_OpenSource/tree/tucana-q-oss) |
-| toco-q-oss | MI Note 10 | Android Q | LA.UM.8.9.r1-03800-sm6150.0-1 | [toco-q-oss](https://github.com/MiCode/Xiaomi_Kernel_OpenSource/tree/toco-q-oss) |
-| ulysse-n-oss | Redmi Note 5A | Android N | LA.UM.5.6.r1-04600-89xx.0 | [ulysse-n-oss](https://github.com/MiCode/Xiaomi_Kernel_OpenSource/tree/ulysse-n-oss) |
-| umi-q-oss | Mi 10 Pro, Mi 10 | Android Q | LA.UM.8.12.r1-06000-sm8250.0 | [umi-q-oss](https://github.com/MiCode/Xiaomi_Kernel_OpenSource/tree/umi-q-oss) |
-| vangogh-q-oss | Mi 10 Lite 5G, Mi 10 Lite Zoom | Android Q | LA.UM.8.13.r1-04700-SAIPAN.0 | [vangogh-q-oss](https://github.com/MiCode/Xiaomi_Kernel_OpenSource/tree/vangogh-q-oss) |
-| vayu-r-oss | Redmi POCO X3 Pro | Android R | LA.UM.9.1.r1-07000-SMxxx0.0 | [vayu-r-oss](https://github.com/MiCode/Xiaomi_Kernel_OpenSource/tree/vayu-r-oss) |  
-| venus-r-oss | Mi 11 | Android R | LA.UM.9.14.r1-10000-LAHAINA.0 | [venus-r-oss](https://github.com/MiCode/Xiaomi_Kernel_OpenSource/tree/venus-r-oss) |
-| vili-r-oss | Xiaomi 11T Pro | Android R | LA.UM.9.14.r1-16700-LAHAINA.0 | [vili-r-oss](https://github.com/MiCode/Xiaomi_Kernel_OpenSource/tree/vili-r-oss) |
-| violet-p-oss | Redmi Note 7Pro | Android P | LA.UM.7.9.r1-03500-sm6150.0 | [violet-p-oss](https://github.com/MiCode/Xiaomi_Kernel_OpenSource/tree/violet-p-oss) |
-| violet-q-oss | Redmi Note 7 Pro | Android Q | LA.UM.8.9.r1-04400-SM6xx.0-1 | [violet-q-oss](https://github.com/MiCode/Xiaomi_Kernel_OpenSource/tree/violet-q-oss) |
-| whyred-n-oss | Redmi Note 5 | Android N | LA.UM.6.1.r1-11000-sdm660.0 | [whyred-n-oss](https://github.com/MiCode/Xiaomi_Kernel_OpenSource/tree/whyred-n-oss) |
-| whyred-o-oss | Redmi Note 5, Redmi Note6 Pro, Mi 6X | Android O | LA.UM.6.2.r1-06100-sdm660.0 | [whyred-o-oss](https://github.com/MiCode/Xiaomi_Kernel_OpenSource/tree/whyred-o-oss) |
-| willow-p-oss | Redmi Note 8T | Android P | LA.UM.7.11.r1-02700-NICOBAR.0 | [willow-p-oss](https://github.com/MiCode/Xiaomi_Kernel_OpenSource/tree/willow-p-oss) |
-| ysl-o-oss | Redmi S2 | Android O | LA.UM.6.6.r1-06200-89xx.0 | [ysl-o-oss](https://github.com/MiCode/Xiaomi_Kernel_OpenSource/tree/ysl-o-oss) |
-| ysl-p-oss | Redmi S2 | Android P | LA.UM.7.6.r1-03900-89xx.0 | [ysl-p-oss](https://github.com/MiCode/Xiaomi_Kernel_OpenSource/tree/ysl-p-oss) |
-| zeus-s-oss | Mi 12, Mi 12 Pro | Android S | LA.VENDOR.1.0.r1-09100-r1.0.r1 | [zeus-s-oss](https://github.com/MiCode/Xiaomi_Kernel_OpenSource/tree/zeus-s-oss) |
-| zijin-s-oss | Xiaomi Civi 1S | Android S | LA.UM.9.14.r1-18300.05-LAHAINA.QSSI12.0-1 | [zijin-s-oss](https://github.com/MiCode/Xiaomi_Kernel_OpenSource/tree/zijin-s-oss) |
-| ziyi-s-oss | Xiaomi civi2 | Android S | LA.VENDOR.1.0.r1-13100-r1.0.r1_00037.0 | [ziyi-s-oss](https://github.com/MiCode/Xiaomi_Kernel_OpenSource/tree/ziyi-s-oss) |
-| munch-s-oss | Redmi K40S | Android S | LA.UM.9.12.r1-13300-SMxx50.QSSI12.0-1 | [munch-s-oss](https://github.com/MiCode/Xiaomi_Kernel_OpenSource/tree/munch-s-oss) |
-| rubens-s-oss | Redmi K50 | Android S | alps-release-s0.mp1.tc8sp2-mt6983 | [rubens-s-oss](https://github.com/MiCode/Xiaomi_Kernel_OpenSource/tree/rubens-s-oss) |
-| yunluo-s-oss | Redmi Pad | Android S | alps-release-s0.mp1.tc8sp2-cs1-xm-V1 | [yunluo-s-oss](https://github.com/MiCode/Xiaomi_Kernel_OpenSource/tree/yunluo-s-oss) |
-| xaga-s-oss | Redmi Note11T Pro | Android S | alps-release-s0.mp1.tc8sp2-mt6983 | [xaga-s-oss](https://github.com/MiCode/Xiaomi_Kernel_OpenSource/tree/xaga-s-oss) |
-| socrates-t-oss | Redmi K60 Pro | Android T | LA.VENDOR.13.2.0.r1-07300-r1.0.r1_00020.0 |[socrates-t-oss](https://github.com/MiCode/Xiaomi_Kernel_OpenSource/tree/socrates-t-oss) |
-| ruby-s-oss | Redmi Note12 Pro | Android S | alps-mp-s0.mp1.tc8sp-cs1-V1 |[ruby-s-oss](https://github.com/MiCode/Xiaomi_Kernel_OpenSource/tree/ruby-s-oss) |
-| mayfly-s-oss | Xiaomi 12S | Android S | LA.VENDOR.1.0.r1-13100-r1.0.r1_00037.0 |[mayfly-s-oss](https://github.com/MiCode/Xiaomi_Kernel_OpenSource/tree/mayfly-s-oss) |
-| fuxi-t-oss | Xiaomi 13 | Android T | LA.VENDOR.13.2.0.r1-07300-KAILUA.0 |[fuxi-t-oss](https://github.com/MiCode/Xiaomi_Kernel_OpenSource/tree/fuxi-t-oss) |
-| mondrian-s-oss | Redmi K60 | Android S | LA.VENDOR.1.0.r1-11900-r1.0.r1_00029.0 |[mondrian-s-oss](https://github.com/MiCode/Xiaomi_Kernel_OpenSource/tree/mondrian-s-oss) |
+─▄▀▀▀▀▄─█──█────▄▀▀█─▄▀▀▀▀▄─█▀▀▄
+─█────█─█──█────█────█────█─█──█
+─█────█─█▀▀█────█─▄▄─█────█─█──█
+─▀▄▄▄▄▀─█──█────▀▄▄█─▀▄▄▄▄▀─█▄▄▀
+
+─────────▄██████▀▀▀▀▀▀▄
+─────▄█████████▄───────▀▀▄▄
+──▄█████████████───────────▀▀▄
+▄██████████████─▄▀───▀▄─▀▄▄▄──▀▄
+███████████████──▄▀─▀▄▄▄▄▄▄────█
+█████████████████▀█──▄█▄▄▄──────█
+███████████──█▀█──▀▄─█─█─█───────█
+████████████████───▀█─▀██▄▄──────█
+█████████████████──▄─▀█▄─────▄───█
+█████████████████▀███▀▀─▀▄────█──█
+████████████████──────────█──▄▀──█
+████████████████▄▀▀▀▀▀▀▄──█──────█
+████████████████▀▀▀▀▀▀▀▄──█──────█
+▀████████████████▀▀▀▀▀▀──────────█
+──███████████████▀▀─────█──────▄▀
+──▀█████████████────────█────▄▀
+────▀████████████▄───▄▄█▀─▄█▀
+──────▀████████████▀▀▀──▄███
+──────████████████████████─█
+─────████████████████████──█
+────████████████████████───█
+────██████████████████─────█
+────██████████████████─────█
+────██████████████████─────█
+────██████████████████─────█
+────██████████████████▄▄▄▄▄█
+
+─────────────█─────█─█──█─█───█
+─────────────█─────█─█──█─▀█─█▀
+─────────────█─▄█▄─█─█▀▀█──▀█▀
+─────────────██▀─▀██─█──█───█
+
+KERNEL SOURCE FOR POCO F5 / REDMI NOTE 12 TURBO ( Marble)


### PR DESCRIPTION
Kindly Release Kernel Source for Redmi Note 12 Turbo / Poco F5 (marble). Eagerly waiting for it since long time.

Thanks!