### PR TITLE
Fix uninitialized pointer problem

### DIFF
--- a/drivers/power/supply/ti/bq2597x_charger_pipa.c
+++ b/drivers/power/supply/ti/bq2597x_charger_pipa.c
@@ -2554,7 +2554,6 @@ static int bq2597x_charger_probe(struct i2c_client *client,
 {
 	struct bq2597x *bq;
 	int ret;
-    bq_err("enter cp successfully-cxl");
 	bq = devm_kzalloc(&client->dev, sizeof(struct bq2597x), GFP_KERNEL);
 	if (!bq)
 		return -ENOMEM;


### PR DESCRIPTION
This bq_err refer to the uninitialized pointer *bq, which can cause kernel panic while booting up.